### PR TITLE
chore: add GitHub Actions workflow and remove Travis CI

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -1,0 +1,20 @@
+name: 'default'
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+permissions:
+  security-events: 'write'
+  contents: 'write'
+
+jobs:
+  default:
+    uses: 'rios0rios0/pipelines/.github/workflows/java-maven.yaml@main'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: java
-jdk:
-  - oraclejdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+When a new release is proposed:
+
+1. Create a new branch `bump/x.x.x` (this isn't a long-lived branch!!!);
+2. The Unreleased section on `CHANGELOG.md` gets a version number and date;
+3. Open a Pull Request with the bump version changes targeting the `main` branch;
+4. When the Pull Request is merged, a new Git tag must be created using [GitHub environment](https://github.com/rios0rios0/caa/tags).
+
+Releases to productive environments should run from a tagged version.
+Exceptions are acceptable depending on the circumstances (critical bug fixes that can be cherry-picked, etc.).
+
+## [Unreleased]
+
+### Added
+
+- added GitHub Actions workflow for CI/CD pipeline
+
+### Removed
+
+- removed Travis CI configuration in favor of GitHub Actions

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
         <img src="https://img.shields.io/github/release/rios0rios0/caa.svg?style=for-the-badge&logo=github" alt="Latest Release"/></a>
     <a href="https://github.com/rios0rios0/caa/blob/main/LICENSE">
         <img src="https://img.shields.io/github/license/rios0rios0/caa.svg?style=for-the-badge&logo=github" alt="License"/></a>
+    <a href="https://github.com/rios0rios0/caa/actions/workflows/default.yaml">
+        <img src="https://img.shields.io/github/actions/workflow/status/rios0rios0/caa/default.yaml?branch=main&style=for-the-badge&logo=github" alt="Build Status"/></a>
 </p>
 
 A collection of classic sorting algorithms implemented in Java 8 with a built-in instruction-counting benchmarking framework that measures best-case, worst-case, and average-case performance across varying input sizes. Each algorithm counts the exact number of primitive operations (comparisons, swaps, assignments) executed during sorting, providing concrete empirical data for algorithm analysis.
@@ -54,7 +56,7 @@ A collection of classic sorting algorithms implemented in Java 8 with a built-in
 |-----------|---------|
 | **Language** | Java 8 (lambdas, streams, `OptionalInt`) |
 | **Build** | Apache Maven 3 with `maven-assembly-plugin` |
-| **CI** | Travis CI (Oracle JDK 8) |
+| **CI** | GitHub Actions |
 | **Output** | ANSI terminal colors via escape sequences |
 
 ## Project Structure
@@ -62,7 +64,6 @@ A collection of classic sorting algorithms implemented in Java 8 with a built-in
 ```
 caa/
 ├── pom.xml                                                # Maven build configuration (Java 8, assembly plugin)
-├── .travis.yml                                            # Travis CI configuration (Oracle JDK 8)
 ├── src/
 │   └── main/
 │       ├── java/


### PR DESCRIPTION
## Summary
- Added `default.yaml` GitHub Actions workflow using shared `rios0rios0/pipelines` reusable workflows
- Added build status badge to README
- Removed Travis CI configuration and references
- Added CHANGELOG

## Test plan
- [ ] Verify workflow runs successfully on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)