### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@
 caa/
 ├── .github/
 │   └── workflows/
-│       └── default.yaml          # CI pipeline (delegates to shared java-maven workflow)
+│       └── default.yaml          # CI pipeline (delegates to shared maven-library workflow)
 ├── src/
 │   └── main/
 │       ├── java/
@@ -52,7 +52,7 @@ caa/
 
 ```bash
 mvn clean package
-# Produces: target/CAA-0.1.0-jar-with-dependencies.jar
+# Produces: target/CAA-0.1.1-jar-with-dependencies.jar
 # Typical duration: ~10–15 seconds
 ```
 
@@ -119,7 +119,7 @@ Sort (interface)
 The workflow in `.github/workflows/default.yaml` delegates to the shared reusable pipeline:
 
 ```
-rios0rios0/pipelines/.github/workflows/java-maven.yaml@main
+rios0rios0/pipelines/.github/workflows/maven-library.yaml@main
 ```
 
 It triggers on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to update CI workflow reference (`java-maven.yaml` → `maven-library.yaml`) and JAR filename version (0.1.0 → 0.1.1)
+
 ## [0.1.1] - 2026-04-28
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.