### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,7 +52,7 @@ caa/
 
 ```bash
 mvn clean package
-# Produces: target/CAA-0.1.1-jar-with-dependencies.jar
+# Produces: target/CAA-0.1.2-jar-with-dependencies.jar
 # Typical duration: ~10–15 seconds
 ```
 
@@ -63,7 +63,7 @@ mvn clean package
 mvn exec:java -Dexec.mainClass="com.rios0rios0.Main"
 
 # Run via assembled JAR
-java -jar target/CAA-0.1.0-jar-with-dependencies.jar
+java -jar target/CAA-0.1.2-jar-with-dependencies.jar
 ```
 
 ### Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to update JAR filename version (0.1.1 → 0.1.2) and fix stale 0.1.0 reference in run command
+
 ## [0.1.2] - 2026-05-19
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.