### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -103,7 +103,7 @@ Sort (interface)
 
 - **`Array`** – generates random integer arrays with values in `[0, size*10)` using `java.util.Random` and `OptionalInt` streams.
 - **`Colorize`** – builds ANSI escape sequences supporting bold, italic, underline, and colors (green, blue, red).
-- **`Console`** – provides `success()`, `error()`, and `info()` wrappers that print colorized messages to stdout.
+- **`Console`** – provides `showMsgSuccess()`, `showMsgError()`, and `showMsgInfo()` wrappers (plus `showSyn()`, `showAck()`, and plain `showMsg()`) that print colorized messages to stdout.
 
 ## Sorting Algorithms
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to correct the `Console` utility method names (`success()`/`error()`/`info()` → `showMsgSuccess()`/`showMsgError()`/`showMsgInfo()`)
+
 ## [0.1.4] - 2026-06-03
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.